### PR TITLE
Update manual workflow to accept version as argument

### DIFF
--- a/.github/workflows/docker-manual.yml
+++ b/.github/workflows/docker-manual.yml
@@ -20,7 +20,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: gokite-ai/gokite-chain
   AVALANCHEGO_VERSION: 7c6aba88
-  SUBNETEVM_VERSION: 1.14.2-kite-rc.3
+  SUBNETEVM_VERSION: v1.14.2-kite-rc.3
 
 jobs:
   publish-manual:

--- a/.github/workflows/docker-manual.yml
+++ b/.github/workflows/docker-manual.yml
@@ -15,12 +15,20 @@ on:
         required: false
         type: boolean
         default: false
+      avalanchego_version:
+        description: 'AvalancheGo version to build'
+        required: true
+        type: string
+      subnetevm_version:
+        description: 'SubnetEVM version to build'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: gokite-ai/gokite-chain
-  AVALANCHEGO_VERSION: 7c6aba88
-  SUBNETEVM_VERSION: v1.14.2-kite-rc.3
+  AVALANCHEGO_VERSION: ${{ github.event.inputs.avalanchego_version }}
+  SUBNETEVM_VERSION: ${{ github.event.inputs.subnetevm_version }}
 
 jobs:
   publish-manual:

--- a/.github/workflows/docker-manual.yml
+++ b/.github/workflows/docker-manual.yml
@@ -19,7 +19,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: gokite-ai/gokite-chain
-  AVALANCHEGO_VERSION: 1.14.2-kite-rc.3
+  AVALANCHEGO_VERSION: 7c6aba88
   SUBNETEVM_VERSION: 1.14.2-kite-rc.3
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,8 +7,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: gokite-ai/gokite-chain
-  AVALANCHEGO_VERSION: 1.14.2-kite-rc.3
-  SUBNETEVM_VERSION: 1.14.2-kite-rc.3
+  AVALANCHEGO_VERSION: v1.14.2-kite-rc.3
+  SUBNETEVM_VERSION: v1.14.2-kite-rc.3
 
 jobs:
   publish-latest-release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@
 ARG AVALANCHEGO_VERSION
 ARG SUBNETEVM_VERSION
 
-FROM ghcr.io/gokite-ai/avalanchego:v${AVALANCHEGO_VERSION} AS avalanchego
+FROM ghcr.io/gokite-ai/avalanchego:${AVALANCHEGO_VERSION} AS avalanchego
 
 # ==============================================================================
 # SUBNET-EVM STAGE
 # Imports the Subnet-EVM plugin from the merged AvalancheGo release image
 # ==============================================================================
-FROM ghcr.io/gokite-ai/subnet-evm:v${SUBNETEVM_VERSION} AS subnetevm
+FROM ghcr.io/gokite-ai/subnet-evm:${SUBNETEVM_VERSION} AS subnetevm
 
 # ==============================================================================
 # FINAL STAGE


### PR DESCRIPTION
### Context

This PR updates the manual workflow in a way that it supports tag, ref or branch as input argument and correctly passes that to the Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual Docker builds now require explicit AvalancheGo and SubnetEVM version selections, enabling builds with chosen component releases.
* **Bug Fixes**
  * Updated Docker image version handling to ensure release and prerelease builds use the correct component tags.
  * Aligned manual and automated Docker builds with the published image tag format for more reliable image creation and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->